### PR TITLE
Chore: replaced react-access-boundary with react-access-boundary-v2 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "nprogress": "^0.2.0",
     "polished": "^4.3.1",
     "react": "^18.3.1",
-    "react-access-boundary": "^2.1.4",
+    "react-access-boundary-v2": "^1.1.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^14.1.1",
     "react-icons": "^5.2.1",

--- a/src/components/Hoc/withAuth.tsx
+++ b/src/components/Hoc/withAuth.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react';
-import { AccessProvider } from 'react-access-boundary';
+import { AccessProvider } from 'react-access-boundary-v2';
 import { useQuery } from 'react-query';
 import { Navigate, useLocation } from 'react-router-dom';
 

--- a/src/features/dashboard/components/Users.tsx
+++ b/src/features/dashboard/components/Users.tsx
@@ -1,5 +1,5 @@
 import { Empty } from 'antd';
-import { useAccessContext } from 'react-access-boundary';
+import { useAccessContext } from 'react-access-boundary-v2';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
 

--- a/src/features/dashboard/usersUtils.tsx
+++ b/src/features/dashboard/usersUtils.tsx
@@ -1,5 +1,5 @@
 import { ColumnsType } from 'antd/lib/table';
-import { useAccessContext } from 'react-access-boundary';
+import { useAccessContext } from 'react-access-boundary-v2';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { Link } from 'react-router-dom';

--- a/src/features/profile/general.tsx
+++ b/src/features/profile/general.tsx
@@ -1,5 +1,5 @@
 import { App, Button, Col, Form, Input, Row } from 'antd';
-import { useAccessContext } from 'react-access-boundary';
+import { useAccessContext } from 'react-access-boundary-v2';
 import { useTranslation } from 'react-i18next';
 import { useMutation } from 'react-query';
 

--- a/src/layouts/DashboardLayout/LayoutSider/MenuItems.tsx
+++ b/src/layouts/DashboardLayout/LayoutSider/MenuItems.tsx
@@ -1,7 +1,6 @@
 import { PieChartOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { useCallback } from 'react';
-import { useAccessContext } from 'react-access-boundary';
+import { useAccessContext } from 'react-access-boundary-v2';
 import { useTranslation } from 'react-i18next';
 
 import { translationKeys } from '@/config/translate/i18next';
@@ -38,25 +37,11 @@ const ITEMS: (ITEM | ITEM_GROUP)[] = [
 export const MenuItems = () => {
 	const { t } = useTranslation();
 	const { isAllowedTo } = useAccessContext();
-	const isAllowedPermission = useCallback(
-		(permission: string | string[]) => {
-			if (Array.isArray(permission)) {
-				for (const item of permission) {
-					return isAllowedTo(item);
-				}
-
-				return false;
-			}
-
-			return isAllowedTo(permission);
-		},
-		[isAllowedTo]
-	);
 
 	const transform = (items: typeof ITEMS) =>
 		items
 			?.map((item) =>
-				!item?.permission || isAllowedPermission(item?.permission)
+				!item?.permission || isAllowedTo(item?.permission)
 					? {
 							...item,
 							label: t(item?.label),
@@ -65,7 +50,7 @@ export const MenuItems = () => {
 										children: item?.children
 											? item.children
 													?.map((child) =>
-														!child.permission || isAllowedPermission(child?.permission)
+														!child.permission || isAllowedTo(child?.permission)
 															? { ...child, label: t(child.label) }
 															: undefined
 													)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4507,10 +4507,10 @@ rc-virtual-list@^3.5.1:
     rc-resize-observer "^1.0.0"
     rc-util "^5.15.0"
 
-react-access-boundary@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/react-access-boundary/-/react-access-boundary-2.1.4.tgz#f19332510bc68a30be28a1a46ae00603fab429d5"
-  integrity sha512-oTRi0G5sHSwDodYg1whi7u06KF+6Ra/hjf4I2K61ZbZIM062rsDicxzW71OLG+3qj8tpH6DYHQPTsUTPaN6n6w==
+react-access-boundary-v2@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-access-boundary-v2/-/react-access-boundary-v2-1.1.1.tgz#5821e75dad44b5ba9016b37c07b78de8d981ae9a"
+  integrity sha512-cGZ6HXn4JGp0evIPgay9VJs5qfA2bZhOIn6UMcq0jm7tBkz0wgZitMiVv+MSMeIcstJTWn6sxe5Ux5GRaSmpNQ==
 
 react-base16-styling@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
### Migration from `react-access-boundary` to `react-access-boundary-v2`

Migrating from `react-access-boundary` to `react-access-boundary-v2` is seamless and won't introduce breaking changes. The core functionality remains the same, ensuring your existing permission-based access controls continue to work as expected.

#### Key points:

- **No Breaking Changes**: You can upgrade without needing to refactor existing components or logic.
- **Enhanced Features**: `react-access-boundary-v2` introduces new features like:
  - 🛡️ Secure routes using the RouteGuard component for access control.
  - ✅ Supports single and multiple permission checks.
  - 🔀 Allows AND/OR logic for permission requirements.
  
[Read more](https://www.npmjs.com/package/react-access-boundary-v2)